### PR TITLE
Add development info on versioning and releasing on Maven Central

### DIFF
--- a/org.pathvisio.lib/README.md
+++ b/org.pathvisio.lib/README.md
@@ -1,0 +1,32 @@
+# Development
+
+Releases are created by the release manager and requires permission to submit the release to Maven Central
+(using an approved Sonatype ([oss.sonatype.org](http://oss.sonatype.org/)) account).
+
+## Versioning
+
+Instructions to increase the version to a development (ending with `-SNAPSHOT`) version:
+
+```shell
+mvn versions:set -DnewVersion=4.0.0-SNAPSHOT
+```
+
+Or to a release version:
+
+```shell
+mvn versions:set -DnewVersion=4.0.0
+```
+
+## Making releases
+
+Deploy to Sonatype with the following commands, for snapshots:
+
+```shell
+mvn clean deploy
+```
+
+And releases respectively:
+
+```shell
+mvn clean deploy -P release
+```


### PR DESCRIPTION
Hi @Finterly, as part of the work to release libGPML on Maven Central (via Sonatype) I added instructions for the future on how to increase the version number and make the release.

The first release I intent to make on Maven Central is a development 4.0.0-SNAPSHOT version.