### PR TITLE
add support for unprefixed doi.org urls

### DIFF
--- a/org.pathvisio.lib/src/main/java/org/pathvisio/libgpml/model/GPML2013aReader.java
+++ b/org.pathvisio.lib/src/main/java/org/pathvisio/libgpml/model/GPML2013aReader.java
@@ -370,7 +370,7 @@ public class GPML2013aReader extends GPML2013aFormatAbstract implements GPMLForm
 				// if source is an url, also set as citation urlLink
 				String urlLink = null;
 				if (source != null) {
-					if (source.startsWith("http") || source.startsWith("www")) {
+					if (source.startsWith("http") || source.startsWith("www") || source.startsWith("doi")) {
 						urlLink = source;
 					}
 				}


### PR DESCRIPTION
This would have cleared the last two sync actions we've seen