### PR TITLE
Clamping RelX RelY values to prevent freezing of UI 

### DIFF
--- a/org.pathvisio.lib/src/main/java/org/pathvisio/libgpml/model/DataNode.java
+++ b/org.pathvisio.lib/src/main/java/org/pathvisio/libgpml/model/DataNode.java
@@ -655,15 +655,20 @@ public class DataNode extends ShapedElement implements Xrefable {
 		 * @throws IllegalArgumentException if relX is not between -1.0 and 1.0. t
 		 */
 		public void setRelX(double v) {
-			if (Math.abs(v) <= 1.0) {
-				if (relX != v) {
-					relX = v;
-					updateCoordinates();
-					fireObjectModifiedEvent(PathwayObjectEvent.createCoordinatePropertyEvent(this));
-				}
-			} else {
-				throw new IllegalArgumentException("relX " + v + " should be between -1.0 and 1.0");
+			//Fix: instead off throwing an exception, clamping the value to the valid range and print a warning message.
+			if (v<-1.0) {
+				v = -1.0;
+				System.out.println("Warning: relX value clamped to -1.0");
 			}
+			else if (v>1.0) {
+				v = 1.0;
+				System.out.println("Warning: relX value clamped to 1.0");
+			}
+			if (relX != v) {
+				relX = v;
+				updateCoordinates();
+				fireObjectModifiedEvent(PathwayObjectEvent.createCoordinatePropertyEvent(this));
+				}
 		}
 
 		/**
@@ -687,14 +692,20 @@ public class DataNode extends ShapedElement implements Xrefable {
 		 * @param v the relative y coordinate.
 		 */
 		public void setRelY(double v) {
-			if (Math.abs(v) <= 1.0) {
-				if (relY != v) {
-					relY = v;
-					updateCoordinates();
-					fireObjectModifiedEvent(PathwayObjectEvent.createCoordinatePropertyEvent(this));
-				}
-			} else {
-				throw new IllegalArgumentException("relY " + v + " should be between -1.0 and 1.0");
+			
+			//Fix: instead off throwing an exception, clamping the value to the valid range and print a warning message.
+			if (v<-1.0) {
+				v = -1.0;
+				System.out.println("Warning: relY value clamped to -1.0");
+			}
+			else if (v>1.0) {
+				v = 1.0;
+				System.out.println("Warning: relY value clamped to 1.0");
+			}
+			if (relY != v) {
+				relY = v;
+				updateCoordinates();
+				fireObjectModifiedEvent(PathwayObjectEvent.createCoordinatePropertyEvent(this));
 			}
 		}
 


### PR DESCRIPTION
The earlier logic of throwing an IllegalArgumentException when RelX RelY values were going out of range was causing an UI unresponsiveness. 

I added a clamping logic where if the respective state property value is greater than 1, it clamps it back to 1 and refreshes the pathway property table to showcase the change. 

Similarly, if the value is less than -1, it clamps it back to -1. 

I have attached a screen recording to showcase the fix.

If a value out of range is added, it automatically gets clamped and changed in PathVisio UI. 

In the terminal, there's a display of a warning message regarding the clamping.

The UI changes were implemented in this PR: [https://github.com/PathVisio/pathvisio4-ant/pull/51](url)

https://github.com/user-attachments/assets/f935c32d-188d-4ca3-b809-0c8cc8e066eb

<img width="518" height="226" alt="Screenshot 2026-03-27 162530" src="https://github.com/user-attachments/assets/6a7acc87-2826-458e-bbf8-9020238ca2e0" />

@mkutmon @egonw 
